### PR TITLE
update: hack club webring.

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -129,7 +129,7 @@ onMount(async () => {
       commitDate = '';
     }
     const script = document.createElement('script');
-    script.src = 'https://webring.hackclub.com/embed.min.js';
+    script.src = 'https://webring.hackclub.com/embed.js';
     script.async = true;
     document.body.appendChild(script);
 


### PR DESCRIPTION
This pull request makes a small update to how the webring script is loaded in the Svelte page. The script source URL is changed from the minified version to the standard version.

* Changed the `script.src` in `src/routes/+page.svelte` to use `embed.js` instead of `embed.min.js` when embedding the webring script.