### PR TITLE
update: rebrand to latest 2.01

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -129,7 +129,7 @@ onMount(async () => {
       commitDate = '';
     }
     const script = document.createElement('script');
-    script.src = 'https://webring.hackclub.com/embed.min.js';
+    script.src = 'https://webring.hackclub.com/embed.js';
     script.async = true;
     document.body.appendChild(script);
 


### PR DESCRIPTION
This pull request updates the script source for the Hack Club Webring embed in the `src/routes/+page.svelte` file. The change switches from the minified version to the standard version of the script, to make base same as main (v2.01) on #20 